### PR TITLE
Add locator deprecation warning and additional examples

### DIFF
--- a/source/locating-elements.rst
+++ b/source/locating-elements.rst
@@ -3,6 +3,11 @@
 Locating Elements
 -----------------
 
+.. note::
+
+   If you are using Selenium 4.0.0 or higher, there is a deprecation notice for the find_element_by\_\* functions. 
+   `DeprecationWarning: find_element_by\_\* commands are deprecated. Please use find_element() instead`
+
 There are various strategies to locate elements in a page.  You can use the most
 appropriate one for your case.  Selenium provides the following methods to
 locate elements in a page:

--- a/source/locating-elements.rst
+++ b/source/locating-elements.rst
@@ -12,32 +12,54 @@ There are various strategies to locate elements in a page.  You can use the most
 appropriate one for your case.  Selenium provides the following methods to
 locate elements in a page. :ref:`1<Deprecation of locator methods>`
 
-- `find_element_by_id`
-- `find_element_by_name`
-- `find_element_by_xpath`
-- `find_element_by_link_text`
-- `find_element_by_partial_link_text`
-- `find_element_by_tag_name`
-- `find_element_by_class_name`
-- `find_element_by_css_selector`
+.. list-table:: Available Locator Methods
+   :header-rows: 1
 
-
-**To find multiple elements (these methods will return a list):**
-
-- `find_elements_by_name`
-- `find_elements_by_xpath`
-- `find_elements_by_link_text`
-- `find_elements_by_partial_link_text`
-- `find_elements_by_tag_name`
-- `find_elements_by_class_name`
-- `find_elements_by_css_selector`
-
-
-Apart from the methods given above, there are two methods which
-might be useful for locating page elements:
-
-- `find_element`
-- `find_elements`
+   * - HTML locator
+     - Description
+     - Legacy method (single element)
+     - Legacy method (multiples/list)
+     - Selenium 4.0.0+
+   * - class name
+     - css selector
+     - id
+     - link text
+     - partial link text
+     - name
+     - tag name
+     - xpath
+   * - Locate element whose class name contains the search value. Compound class names are not permitted.
+     - Locate element matching a CSS selector
+     - Locate element whose ID attribute matches the search value
+     - Locate anchor element whose visible text matches the search value
+     - Locate anchor element whose visible text contains the search value
+     - Locate element whose NAME attribute matches the search value
+     - Locate element whose tag name matches the search value
+     - Locate element matching an XPath expression
+   * - find_element_by_class_name
+     - find_element_by_css_selector
+     - find_element_by_id
+     - find_element_by_link_text
+     - find_element_by_partial_link_text
+     - find_element_by_name
+     - find_element_by_tag_name
+     - find_element_by_xpath
+   * - find_elements_by_class_name
+     - find_elements_by_css_selector
+     - find_elements_by_id
+     - find_elements_by_link_text
+     - find_elements_by_partial_link_text
+     - find_elements_by_name
+     - find_elements_by_tag_name
+     - find_elements_by_xpath
+   * - By.CLASS_NAME
+     - By.CSS_SELECTOR
+     - By.ID
+     - By.LINK_TEXT
+     - By.PARTIAL_TEXT
+     - By.NAME
+     - By.TAG_NAME
+     - By.XPATH
 
 Example usage::
 
@@ -48,18 +70,6 @@ Example usage::
   
   foobarRows = driver.find_elements(By.XPATH, '//table[@id="foobar"]/tbody/tr')
   # list all rows in `table` element with attribute `id` set to 'foobar'
-
-
-These are the attributes available for `By` class::
-
-    ID = "id"
-    XPATH = "xpath"
-    LINK_TEXT = "link text"
-    PARTIAL_LINK_TEXT = "partial link text"
-    NAME = "name"
-    TAG_NAME = "tag name"
-    CLASS_NAME = "class name"
-    CSS_SELECTOR = "css selector"
 
 
 Locating by Id

--- a/source/locating-elements.rst
+++ b/source/locating-elements.rst
@@ -86,6 +86,9 @@ For instance, consider this page source::
 The form element can be located like this::
 
   login_form = driver.find_element_by_id('loginForm')
+  
+  # alternate method (v4.0.0+)
+  login_form = driver.find_element(By.ID, 'loginForm')
 
 
 Locating by Name
@@ -117,6 +120,9 @@ The username & password elements can be located like this::
 This will give the "Login" button as it occurs before the "Clear" button::
 
   continue = driver.find_element_by_name('continue')
+  
+  # alternate method (v4.0.0+)
+  continue = driver.find_element(By.NAME, 'continue')
 
 
 Locating by XPath

--- a/source/locating-elements.rst
+++ b/source/locating-elements.rst
@@ -3,9 +3,10 @@
 Locating Elements
 -----------------
 
-.. note::
+::
 
-   If you are using Selenium 4.0.0 or higher, there is a deprecation notice for the find_element_by_* functions. Please use find_element() instead.
+   Note: If you are using Selenium 4.0.0 or higher, there is a deprecation notice for find_element_by_* methods. 
+   Please use find_element(By.*) instead.
 
 There are various strategies to locate elements in a page.  You can use the most
 appropriate one for your case.  Selenium provides the following methods to
@@ -42,9 +43,12 @@ might be useful for locating page elements:
 Example usage::
 
   from selenium.webdriver.common.by import By
-
-  driver.find_element(By.XPATH, '//button[text()="Some text"]')
-  driver.find_elements(By.XPATH, '//button')
+  
+  # returns single button (only or first instance)
+  myButton = driver.find_element(By.XPATH, '//button[text()="Some text"]')
+  
+  # returns list of all rows in table of id 'foobar'
+  foobarRows = driver.find_elements(By.XPATH, '//table[@id="foobar"]/th/tr')
 
 
 These are the attributes available for `By` class::

--- a/source/locating-elements.rst
+++ b/source/locating-elements.rst
@@ -5,8 +5,7 @@ Locating Elements
 
 .. note::
 
-   If you are using Selenium 4.0.0 or higher, there is a deprecation notice for the find_element_by\_\* functions. 
-   `DeprecationWarning: find_element_by\_\* commands are deprecated. Please use find_element() instead`
+   If you are using Selenium 4.0.0 or higher, there is a deprecation notice for the find_element_by_* functions. Please use find_element() instead.
 
 There are various strategies to locate elements in a page.  You can use the most
 appropriate one for your case.  Selenium provides the following methods to

--- a/source/locating-elements.rst
+++ b/source/locating-elements.rst
@@ -160,46 +160,48 @@ For instance, consider this page source::
    </body>
    </html>
 
-The form elements can be located like this::
+The form element can be located like this [#]_::
 
-  login_form = driver.find_element_by_xpath("/html/body/form[1]")
-  login_form = driver.find_element_by_xpath("//form[1]")
-  login_form = driver.find_element_by_xpath("//form[@id='loginForm']")
+   login_form = driver.find_element_by_xpath("/html/body/form[1]")
+   # Find form element by absolute path
+   
+   login_form = driver.find_element_by_xpath("//form[1]")
+   # Find the first form element in the html
+   
+   login_form = driver.find_element_by_xpath("//form[@id='loginForm']")
+   # Find the form element with attribute `id` set to `loginForm`
+   
+   login_form = driver.find_element(By.XPATH, "//form[@id='loginForm']")
+   # (v4.0.0+) Find first `input` element with attribute `name` set to `username`
 
-
-1. Absolute path (would break if the HTML was changed only slightly)
-
-2. First form element in the HTML
-
-3. The form element with attribute `id` set to `loginForm`
+.. [#] Note: Use absolute paths only if necessary. Methods will break if the HTML is changed even slightly.
 
 The username element can be located like this::
 
-  username = driver.find_element_by_xpath("//form[input/@name='username']")
-  username = driver.find_element_by_xpath("//form[@id='loginForm']/input[1]")
-  username = driver.find_element_by_xpath("//input[@name='username']")
-
-1. First form element with an input child element with `name` set to `username`
-
-2. First input child element of the form element with attribute `id` set to
-   `loginForm`
-
-3. First input element with attribute `name` set to `username`
+    username = driver.find_element_by_xpath("//form[input/@name='username']")
+    # Find first `form` element with an `input` child element with `name` set to `username`
+    
+    username = driver.find_element_by_xpath("//form[@id='loginForm']/input[1]")
+    # Find first `input` child element of the `form` element with attribute `id` set to `loginForm`
+    
+    username = driver.find_element_by_xpath("//input[@name='username']")
+    # Find first `input` element with attribute `name` set to `username`
+    
+    username = driver.find_element(By.XPATH, "//input[@name='username']")
+    # (v4.0.0+) Find first `input` element with attribute `name` set to `username`
 
 The "Clear" button element can be located like this::
 
   clear_button = driver.find_element_by_xpath("//input[@name='continue'][@type='button']")
+  # Find `input` with attribute `name` set to `continue` and attribute `type` set to `button`
+  
   clear_button = driver.find_element_by_xpath("//form[@id='loginForm']/input[4]")
+  # Find fourth `input` child of the `form` element with attribute `id` set to `loginForm`
+  
+  clear_button = driver.find_element(By.XPATH, "//input[@name='continue'][@type='button']")
+  # (v4.0.0+) Find `input` element with attribute `type` set to `button` and `name` set to `continue`
 
-
-1. Input with attribute `name` set to `continue` and attribute `type` set to
-   `button`
-
-2. Fourth input child element of the form element with attribute `id` set to
-   `loginForm`
-
-These examples cover some basics, but in order to learn more, the following
-references are recommended:
+These examples cover a few basics only. To learn more, the following references are recommended:
 
 * `W3Schools XPath Tutorial <https://www.w3schools.com/xml/xpath_intro.asp>`_
 * `W3C XPath Recommendation <http://www.w3.org/TR/xpath>`_
@@ -207,15 +209,20 @@ references are recommended:
   <http://www.zvon.org/comp/r/tut-XPath_1.html>`_
   - with interactive examples.
 
-Here is a couple of very useful Add-ons that can assist in discovering the XPath
-of an element:
+Additionally, there are useful browser extensions to assist in discovering XPaths:
 
 * `xPath Finder
   <https://addons.mozilla.org/en-US/firefox/addon/xpath_finder>`_ -
-  Plugin to get the elements xPath.
+  for Firefox
 * `XPath Helper
   <https://chrome.google.com/webstore/detail/hgimnogjllphhhkhlmebbmlgjoejdpjl>`_ -
   for Google Chrome
+* `Ruto XPath Finder
+  <https://chrome.google.com/webstore/detail/ruto-xpath-finder/ilcoelkkcokgeeijnopjnolmmighnppp>`_ -
+  for Google Chrome, specifically engineered for use with Selenium
+* `SelectorsHub
+  <https://selectorshub.com/selectorshub/>`_ -
+  for most major browsers (Chrome, Safari, Firefox, Edge)
 
 
 Locating Hyperlinks by Link Text

--- a/source/locating-elements.rst
+++ b/source/locating-elements.rst
@@ -10,7 +10,7 @@ Locating Elements
 
 There are various strategies to locate elements in a page.  You can use the most
 appropriate one for your case.  Selenium provides the following methods to
-locate elements in a page:
+locate elements in a page. :ref:`1<Deprecation of locator methods>`
 
 - `find_element_by_id`
 - `find_element_by_name`
@@ -33,22 +33,21 @@ locate elements in a page:
 - `find_elements_by_css_selector`
 
 
-Apart from the public methods given above, there are two private methods which
+Apart from the methods given above, there are two methods which
 might be useful for locating page elements:
 
 - `find_element`
 - `find_elements`
 
-
 Example usage::
 
   from selenium.webdriver.common.by import By
   
-  # returns single button (only or first instance)
   myButton = driver.find_element(By.XPATH, '//button[text()="Some text"]')
+  # find single button (only or first instance)
   
-  # returns list of all rows in table of id 'foobar'
-  foobarRows = driver.find_elements(By.XPATH, '//table[@id="foobar"]/th/tr')
+  foobarRows = driver.find_elements(By.XPATH, '//table[@id="foobar"]/tbody/tr')
+  # list all rows in `table` element with attribute `id` set to 'foobar'
 
 
 These are the attributes available for `By` class::
@@ -87,8 +86,8 @@ The form element can be located like this::
 
   login_form = driver.find_element_by_id('loginForm')
   
-  # alternate method (v4.0.0+)
   login_form = driver.find_element(By.ID, 'loginForm')
+  # (v4.0.0+) Alternate method
 
 
 Locating by Name
@@ -121,8 +120,8 @@ This will give the "Login" button as it occurs before the "Clear" button::
 
   continue = driver.find_element_by_name('continue')
   
-  # alternate method (v4.0.0+)
   continue = driver.find_element(By.NAME, 'continue')
+  # (v4.0.0+) Alternate method
 
 
 Locating by XPath
@@ -160,7 +159,7 @@ For instance, consider this page source::
    </body>
    </html>
 
-The form element can be located like this [#]_::
+The form element can be located like this: :ref:`2<Absolute path warning>`)::
 
    login_form = driver.find_element_by_xpath("/html/body/form[1]")
    # Find form element by absolute path
@@ -173,8 +172,6 @@ The form element can be located like this [#]_::
    
    login_form = driver.find_element(By.XPATH, "//form[@id='loginForm']")
    # (v4.0.0+) Find first `input` element with attribute `name` set to `username`
-
-.. [#] Note: Use absolute paths only if necessary. Methods will break if the HTML is changed even slightly.
 
 The username element can be located like this::
 
@@ -247,6 +244,10 @@ The continue.html link can be located like this::
 
   continue_link = driver.find_element_by_link_text('Continue')
   continue_link = driver.find_element_by_partial_link_text('Conti')
+  
+  continue_link = driver.find_element(By.LINK_TEXT, 'Continue')
+  continue_link = driver.find_element(By.PARTIAL_LINK_TEXT, 'Conti')
+  # (v4.0.0+) Alternate methods
 
 
 Locating Elements by Tag Name
@@ -268,6 +269,9 @@ For instance, consider this page source::
 The heading (h1) element can be located like this::
 
   heading1 = driver.find_element_by_tag_name('h1')
+  
+  heading1 = driver.find_element(By.TAG_NAME, 'h1')
+  # (v4.0.0+) Alternate method
 
 
 Locating Elements by Class Name
@@ -289,6 +293,9 @@ For instance, consider this page source::
 The "p" element can be located like this::
 
   content = driver.find_element_by_class_name('content')
+  
+  content = driver.find_element(By.CLASS_NAME, 'content')
+  # (v4.0.0+) Alternate method
 
 Locating Elements by CSS Selectors
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -309,8 +316,21 @@ For instance, consider this page source::
 
 The "p" element can be located like this::
 
-  content = driver.find_element_by_css_selector('p.content')
+   content = driver.find_element_by_css_selector('p.content')
+   
+   content = driver.find_element(By.CSS_SELECTOR, 'p.content')
+   # (v4.0.0+) Alternate method
 
 `Sauce Labs has good documentation
 <https://saucelabs.com/resources/articles/selenium-tips-css-selectors>`_ on CSS
 selectors.
+
+Footnotes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. _Deprecation of locator methods
+[1] If you are using Selenium 4.0.0 or higher, there is a deprecation notice for find_element_by\_* methods. 
+Please use find_element(By.*) instead.
+
+.. _Absolute path warning
+[2] Use absolute paths only if necessary. Methods will break if the HTML is changed even slightly.


### PR DESCRIPTION
Selenium 4.0.0 deprecated find_element_by_* methods. Add a notice to the page, including footnotes. Add additional examples with the preferred method under each locator example. Add table to page introduction to compare locator methods.